### PR TITLE
Add Keystone security monitor as a submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,4 @@
+[submodule "lib/utils/experimental/keystone"]
+	path = lib/utils/experimental/keystone
+	url = https://github.com/keystone-enclave/sm
+	branch = master

--- a/firmware/fw_base.ldS
+++ b/firmware/fw_base.ldS
@@ -76,6 +76,45 @@
 
 	/* End of the read-write data sections */
 
-	. = ALIGN(0x1000); /* Need this to create proper sections */
+  . = ALIGN(0x1000); /* Need this to create proper sections */
 
 	PROVIDE(_fw_end = .);
+
+  /* # Sanctum params */
+	/* ================ */
+	. = 0x801ff000; /* the last page before the payload */
+
+	/* ## manufacturer_keys : */
+
+	/* 32 Bytes : manufacturer public key */
+	PROVIDE( sanctum_m_public_key = . );
+	. += 0x20;
+
+	/* 32 Bytes : device public key */
+	PROVIDE( sanctum_dev_public_key = . );
+	. += 0x20;
+
+	/* 64 Bytes : device secret key */
+	PROVIDE( sanctum_dev_secret_key = . );
+	. += 0x40;
+
+	/* ## security_monitor_keys : */
+
+	/* 64 Bytes : security monitor hash */
+	PROVIDE( sanctum_sm_hash = . );
+	. += 0x40;
+
+	/* 32 Bytes : security monitor public key */
+	PROVIDE( sanctum_sm_public_key = . );
+	. += 0x20;
+
+	/* 64 Bytes : security monitor secret key */
+	PROVIDE( sanctum_sm_secret_key = . );
+	. += 0x40;
+
+	/* 64 Bytes : security monitor's signature by device */
+	PROVIDE( sanctum_sm_signature = . );
+	. += 0x40;
+
+
+

--- a/include/sbi/sbi_ecall.h
+++ b/include/sbi/sbi_ecall.h
@@ -26,6 +26,7 @@ struct sbi_ecall_extension {
 	unsigned long extid_end;
 	int (* probe)(unsigned long extid, unsigned long *out_val);
 	int (* handle)(unsigned long extid, unsigned long funcid,
+           struct sbi_trap_regs* regs,
 		       unsigned long *args, unsigned long *out_val,
 		       struct sbi_trap_info *out_trap);
 };

--- a/include/sbi/sbi_tlb.h
+++ b/include/sbi/sbi_tlb.h
@@ -59,4 +59,8 @@ int sbi_tlb_request(ulong hmask, ulong hbase, struct sbi_tlb_info *tinfo);
 
 int sbi_tlb_init(struct sbi_scratch *scratch, bool cold_boot);
 
+extern unsigned long tlb_sync_off;
+extern unsigned long tlb_fifo_off;
+extern unsigned long tlb_fifo_mem_off;
+
 #endif

--- a/include/sbi_utils/experimental/keystone/pmp.h
+++ b/include/sbi_utils/experimental/keystone/pmp.h
@@ -1,0 +1,106 @@
+//******************************************************************************
+// Copyright (c) 2018, The Regents of the University of California (Regents).
+// All Rights Reserved. See LICENSE for license details.
+//------------------------------------------------------------------------------
+#ifndef _PMP_H_
+#define _PMP_H_
+
+#include "sm.h"
+#include <sbi/riscv_atomic.h>
+#include <errno.h>
+
+#define PMP_N_REG         8 //number of PMP registers
+#define PMP_MAX_N_REGION  16 //maximum number of PMP regions
+
+#define SET_BIT(bitmap, n) (bitmap |= (0x1 << (n)))
+#define UNSET_BIT(bitmap, n) (bitmap &= ~(0x1 << (n)))
+#define TEST_BIT(bitmap, n) (bitmap & (0x1 << (n)))
+
+enum pmp_priority {
+  PMP_PRI_ANY,
+  PMP_PRI_TOP,
+  PMP_PRI_BOTTOM,
+};
+
+#define PMP_ALL_PERM  (PMP_W | PMP_X | PMP_R)
+#define PMP_NO_PERM   0
+
+#if __riscv_xlen == 64
+# define LIST_OF_PMP_REGS  X(0,0)  X(1,0)  X(2,0)  X(3,0) \
+                           X(4,0)  X(5,0)  X(6,0)  X(7,0) \
+                           X(8,2)  X(9,2)  X(10,2) X(11,2) \
+                          X(12,2) X(13,2) X(14,2) X(15,2)
+# define PMP_PER_GROUP  8
+#else
+# define LIST_OF_PMP_REGS  X(0,0)  X(1,0)  X(2,0)  X(3,0) \
+                           X(4,1)  X(5,1)  X(6,1)  X(7,1) \
+                           X(8,2)  X(9,2)  X(10,2) X(11,2) \
+                           X(12,3) X(13,3) X(14,3) X(15,3)
+# define PMP_PER_GROUP  4
+#endif
+
+#define PMP_SET(n, g, addr, pmpc) \
+{ uintptr_t oldcfg = csr_read(pmpcfg##g); \
+  pmpc |= (oldcfg & ~((uintptr_t)0xff << (uintptr_t)8*(n%PMP_PER_GROUP))); \
+  asm volatile ("la t0, 1f\n\t" \
+                "csrrw t0, mtvec, t0\n\t" \
+                "csrw pmpaddr"#n", %0\n\t" \
+                "csrw pmpcfg"#g", %1\n\t" \
+                "sfence.vma\n\t"\
+                ".align 2\n\t" \
+                "1: csrw mtvec, t0 \n\t" \
+                : : "r" (addr), "r" (pmpc) : "t0"); \
+}
+
+#define PMP_UNSET(n, g) \
+{ uintptr_t pmpc = csr_read(pmpcfg##g); \
+  pmpc &= ~((uintptr_t)0xff << (uintptr_t)8*(n%PMP_PER_GROUP)); \
+  asm volatile ("la t0, 1f \n\t" \
+                "csrrw t0, mtvec, t0 \n\t" \
+                "csrw pmpaddr"#n", %0\n\t" \
+                "csrw pmpcfg"#g", %1\n\t" \
+                "sfence.vma\n\t"\
+                ".align 2\n\t" \
+                "1: csrw mtvec, t0" \
+                : : "r" (0), "r" (pmpc) : "t0"); \
+}
+
+#define PMP_ERROR(error, msg) {\
+  sbi_printf("%s:" msg "\n", __func__);\
+  return error; \
+}
+
+/* PMP IPI mailbox */
+struct ipi_msg{
+  atomic_t pending;
+  uint8_t perm;
+};
+
+/* PMP region type */
+struct pmp_region
+{
+  uint64_t size;
+  uint8_t addrmode;
+  uintptr_t addr;
+  int allow_overlap;
+  int reg_idx;
+};
+
+typedef int pmpreg_id;
+typedef int region_id;
+
+/* external functions */
+int pmp_region_init_atomic(uintptr_t start, uint64_t size, enum pmp_priority pri, region_id* rid, int allow_overlap);
+int pmp_region_init(uintptr_t start, uint64_t size, enum pmp_priority pri, region_id* rid, int allow_overlap);
+int pmp_region_free_atomic(region_id region);
+int pmp_set_keystone(region_id n, uint8_t perm);
+int pmp_set_global(region_id n, uint8_t perm);
+int pmp_unset(region_id n);
+int pmp_unset_global(region_id n);
+int pmp_detect_region_overlap_atomic(uintptr_t base, uintptr_t size);
+void handle_pmp_ipi();
+
+uintptr_t pmp_region_get_addr(region_id i);
+uint64_t pmp_region_get_size(region_id i);
+
+#endif

--- a/include/sbi_utils/experimental/keystone/sm-sbi.h
+++ b/include/sbi_utils/experimental/keystone/sm-sbi.h
@@ -1,0 +1,29 @@
+//******************************************************************************
+// Copyright (c) 2018, The Regents of the University of California (Regents).
+// All Rights Reserved. See LICENSE for license details.
+//------------------------------------------------------------------------------
+#ifndef _KEYSTONE_SBI_H_
+#define _KEYSTONE_SBI_H_
+
+#include <stdint.h>
+#include <stddef.h>
+
+typedef uintptr_t enclave_ret_code;
+
+uintptr_t mcall_sm_create_enclave(uintptr_t create_args);
+
+uintptr_t mcall_sm_destroy_enclave(unsigned long eid);
+
+uintptr_t mcall_sm_run_enclave(uintptr_t* regs, unsigned long eid);
+uintptr_t mcall_sm_exit_enclave(uintptr_t* regs, unsigned long retval);
+uintptr_t mcall_sm_not_implemented(uintptr_t* regs, unsigned long a0);
+uintptr_t mcall_sm_stop_enclave(uintptr_t* regs, unsigned long request);
+uintptr_t mcall_sm_resume_enclave(uintptr_t* regs, unsigned long eid);
+uintptr_t mcall_sm_attest_enclave(uintptr_t report, uintptr_t data, uintptr_t size);
+uintptr_t mcall_sm_get_sealing_key(uintptr_t seal_key, uintptr_t key_ident,
+                                   size_t key_ident_size);
+uintptr_t mcall_sm_random();
+
+uintptr_t mcall_sm_call_plugin(uintptr_t plugin_id, uintptr_t call_id, uintptr_t arg0, uintptr_t arg1);
+
+#endif

--- a/include/sbi_utils/experimental/keystone/sm.h
+++ b/include/sbi_utils/experimental/keystone/sm.h
@@ -1,0 +1,107 @@
+//******************************************************************************
+// Copyright (c) 2018, The Regents of the University of California (Regents).
+// All Rights Reserved. See LICENSE for license details.
+//------------------------------------------------------------------------------
+#ifndef sm_h
+#define sm_h
+
+#include <stdint.h>
+#include "pmp.h"
+#include "sm-sbi.h"
+#include <sbi/riscv_encoding.h>
+
+#define SMM_BASE  0x80000000
+#define SMM_SIZE  0x200000
+
+#define SBI_SM_CREATE_ENCLAVE    101
+#define SBI_SM_DESTROY_ENCLAVE   102
+#define SBI_SM_ATTEST_ENCLAVE    103
+#define SBI_SM_GET_SEALING_KEY   104
+#define SBI_SM_RUN_ENCLAVE       105
+#define SBI_SM_STOP_ENCLAVE      106
+#define SBI_SM_RESUME_ENCLAVE    107
+#define SBI_SM_RANDOM            108
+#define SBI_SM_EXIT_ENCLAVE     1101
+#define SBI_SM_CALL_PLUGIN      1000
+#define SBI_SM_NOT_IMPLEMENTED  1111
+
+/* error codes */
+#define ENCLAVE_NOT_IMPLEMENTED             (enclave_ret_code)-2U
+#define ENCLAVE_UNKNOWN_ERROR               (enclave_ret_code)-1U
+#define ENCLAVE_SUCCESS                     (enclave_ret_code)0
+#define ENCLAVE_INVALID_ID                  (enclave_ret_code)1
+#define ENCLAVE_INTERRUPTED                 (enclave_ret_code)2
+#define ENCLAVE_PMP_FAILURE                 (enclave_ret_code)3
+#define ENCLAVE_NOT_RUNNABLE                (enclave_ret_code)4
+#define ENCLAVE_NOT_DESTROYABLE             (enclave_ret_code)5
+#define ENCLAVE_REGION_OVERLAPS             (enclave_ret_code)6
+#define ENCLAVE_NOT_ACCESSIBLE              (enclave_ret_code)7
+#define ENCLAVE_ILLEGAL_ARGUMENT            (enclave_ret_code)8
+#define ENCLAVE_NOT_RUNNING                 (enclave_ret_code)9
+#define ENCLAVE_NOT_RESUMABLE               (enclave_ret_code)10
+#define ENCLAVE_EDGE_CALL_HOST              (enclave_ret_code)11
+#define ENCLAVE_NOT_INITIALIZED             (enclave_ret_code)12
+#define ENCLAVE_NO_FREE_RESOURCE            (enclave_ret_code)13
+#define ENCLAVE_SBI_PROHIBITED              (enclave_ret_code)14
+#define ENCLAVE_ILLEGAL_PTE                 (enclave_ret_code)15
+#define ENCLAVE_NOT_FRESH                   (enclave_ret_code)16
+
+#define PMP_UNKNOWN_ERROR                   -1U
+#define PMP_SUCCESS                         0
+#define PMP_REGION_SIZE_INVALID             20
+#define PMP_REGION_NOT_PAGE_GRANULARITY     21
+#define PMP_REGION_NOT_ALIGNED              22
+#define PMP_REGION_MAX_REACHED              23
+#define PMP_REGION_INVALID                  24
+#define PMP_REGION_OVERLAP                  25
+#define PMP_REGION_IMPOSSIBLE_TOR           26
+
+void sm_init(bool cold_boot);
+
+/* platform specific functions */
+#define ATTESTATION_KEY_LENGTH  64
+void sm_retrieve_pubkey(void* dest);
+void sm_sign(void* sign, const void* data, size_t len);
+int sm_derive_sealing_key(unsigned char *key,
+                          const unsigned char *key_ident,
+                          size_t key_ident_size,
+                          const unsigned char *enclave_hash);
+
+/* creation parameters */
+struct keystone_sbi_pregion
+{
+  uintptr_t paddr;
+  size_t size;
+};
+struct runtime_va_params_t
+{
+  uintptr_t runtime_entry;
+  uintptr_t user_entry;
+  uintptr_t untrusted_ptr;
+  uintptr_t untrusted_size;
+};
+
+struct runtime_pa_params
+{
+  uintptr_t dram_base;
+  uintptr_t dram_size;
+  uintptr_t runtime_base;
+  uintptr_t user_base;
+  uintptr_t free_base;
+};
+
+struct keystone_sbi_create
+{
+  struct keystone_sbi_pregion epm_region;
+  struct keystone_sbi_pregion utm_region;
+
+  uintptr_t runtime_paddr;
+  uintptr_t user_paddr;
+  uintptr_t free_paddr;
+
+  struct runtime_va_params_t params;
+  unsigned int* eid_pptr;
+};
+
+int osm_pmp_set(uint8_t perm);
+#endif

--- a/include/sbi_utils/experimental/keystone/sm_sbi_opensbi.h
+++ b/include/sbi_utils/experimental/keystone/sm_sbi_opensbi.h
@@ -1,0 +1,23 @@
+#ifndef _SM_SBI_OPENSBI_H_
+#define _SM_SBI_OPENSBI_H_
+
+#define SBI_SM_EVENT 0x0100
+#include "sbi/sbi_trap.h"
+#include "sbi/sbi_error.h"
+#include "sbi/sbi_scratch.h"
+#include <sbi/sbi_ecall.h>
+/* Inbound interfaces */
+extern struct sbi_ecall_extension ecall_keystone_enclave;
+#define SBI_EXT_EXPERIMENTAL_KEYSTONE_ENCLAVE 0x08424b45 // BKE (Berkeley Keystone Enclave)
+//int sbi_sm_interface(struct sbi_scratch *scratch, unsigned long extension_id,
+//                     struct sbi_trap_regs  *regs,
+//                     unsigned long *out_val,
+//                     struct sbi_trap_info *out_trap);
+//void sm_ipi_process();
+
+void register_pmp_ipi();
+int sm_sbi_send_ipi(uintptr_t recipient_mask);
+
+/* Outbound interfaces */
+//int sm_sbi_send_ipi(uintptr_t recipient_mask);
+#endif /*_SM_SBI_OPENSBI_H_*/

--- a/lib/sbi/sbi_ecall.c
+++ b/lib/sbi/sbi_ecall.c
@@ -113,6 +113,7 @@ int sbi_ecall_handler(struct sbi_trap_regs *regs)
 	ext = sbi_ecall_find_extension(extension_id);
 	if (ext && ext->handle) {
 		ret = ext->handle(extension_id, func_id,
+          regs,
 				  args, &out_val, &trap);
 		if (extension_id >= SBI_EXT_0_1_SET_TIMER &&
 		    extension_id <= SBI_EXT_0_1_SHUTDOWN)
@@ -141,7 +142,8 @@ int sbi_ecall_handler(struct sbi_trap_regs *regs)
 		 * case should be handled differently.
 		 */
 		regs->mepc += 4;
-		regs->a0 = ret;
+		if(!regs->zero)
+      regs->a0 = ret;
 		if (!is_0_1_spec)
 			regs->a1 = out_val;
 	}

--- a/lib/sbi/sbi_ecall_base.c
+++ b/lib/sbi/sbi_ecall_base.c
@@ -32,6 +32,7 @@ static int sbi_ecall_base_probe(unsigned long extid, unsigned long *out_val)
 }
 
 static int sbi_ecall_base_handler(unsigned long extid, unsigned long funcid,
+          struct sbi_trap_regs* regs,
 				  unsigned long *args, unsigned long *out_val,
 				  struct sbi_trap_info *out_trap)
 {

--- a/lib/sbi/sbi_ecall_hsm.c
+++ b/lib/sbi/sbi_ecall_hsm.c
@@ -17,6 +17,7 @@
 #include <sbi/riscv_asm.h>
 
 static int sbi_ecall_hsm_handler(unsigned long extid, unsigned long funcid,
+         struct sbi_trap_regs *regs,
 				 unsigned long *args, unsigned long *out_val,
 				 struct sbi_trap_info *out_trap)
 {

--- a/lib/sbi/sbi_ecall_legacy.c
+++ b/lib/sbi/sbi_ecall_legacy.c
@@ -43,6 +43,7 @@ static int sbi_load_hart_mask_unpriv(ulong *pmask, ulong *hmask,
 }
 
 static int sbi_ecall_legacy_handler(unsigned long extid, unsigned long funcid,
+            struct sbi_trap_regs *regs,
 				    unsigned long *args, unsigned long *out_val,
 				    struct sbi_trap_info *out_trap)
 {

--- a/lib/sbi/sbi_ecall_replace.c
+++ b/lib/sbi/sbi_ecall_replace.c
@@ -19,6 +19,7 @@
 #include <sbi/sbi_tlb.h>
 
 static int sbi_ecall_time_handler(unsigned long extid, unsigned long funcid,
+          struct sbi_trap_regs *regs,
 				  unsigned long *args, unsigned long *out_val,
 				  struct sbi_trap_info *out_trap)
 {
@@ -43,6 +44,7 @@ struct sbi_ecall_extension ecall_time = {
 };
 
 static int sbi_ecall_rfence_handler(unsigned long extid, unsigned long funcid,
+            struct sbi_trap_regs *regs,
 				    unsigned long *args, unsigned long *out_val,
 				    struct sbi_trap_info *out_trap)
 {
@@ -110,6 +112,7 @@ struct sbi_ecall_extension ecall_rfence = {
 };
 
 static int sbi_ecall_ipi_handler(unsigned long extid, unsigned long funcid,
+         struct sbi_trap_regs *regs,
 				 unsigned long *args, unsigned long *out_val,
 				 struct sbi_trap_info *out_trap)
 {
@@ -130,6 +133,7 @@ struct sbi_ecall_extension ecall_ipi = {
 };
 
 static int sbi_ecall_srst_handler(unsigned long extid, unsigned long funcid,
+          struct sbi_trap_regs *regs,
 				  unsigned long *args, unsigned long *out_val,
 				  struct sbi_trap_info *out_trap)
 {

--- a/lib/sbi/sbi_ecall_vendor.c
+++ b/lib/sbi/sbi_ecall_vendor.c
@@ -22,6 +22,7 @@ static int sbi_ecall_vendor_probe(unsigned long extid,
 }
 
 static int sbi_ecall_vendor_handler(unsigned long extid, unsigned long funcid,
+            struct sbi_trap_regs* regs,
 				    unsigned long *args, unsigned long *out_val,
 				    struct sbi_trap_info *out_trap)
 {

--- a/lib/sbi/sbi_tlb.c
+++ b/lib/sbi/sbi_tlb.c
@@ -22,9 +22,9 @@
 #include <sbi/sbi_console.h>
 #include <sbi/sbi_platform.h>
 
-static unsigned long tlb_sync_off;
-static unsigned long tlb_fifo_off;
-static unsigned long tlb_fifo_mem_off;
+unsigned long tlb_sync_off;
+unsigned long tlb_fifo_off;
+unsigned long tlb_fifo_mem_off;
 static unsigned long tlb_range_flush_limit;
 
 static void sbi_tlb_flush_all(void)

--- a/platform/generic/platform.c
+++ b/platform/generic/platform.c
@@ -21,6 +21,7 @@
 #include <sbi_utils/timer/fdt_timer.h>
 #include <sbi_utils/ipi/fdt_ipi.h>
 #include <sbi_utils/reset/fdt_reset.h>
+#include <sbi_utils/experimental/keystone/sm.h>
 
 extern const struct platform_override sifive_fu540;
 
@@ -142,6 +143,8 @@ static int generic_final_init(bool cold_boot)
 			return rc;
 	}
 
+  sm_init(cold_boot);
+
 	if (!cold_boot)
 		return 0;
 
@@ -156,6 +159,7 @@ static int generic_final_init(bool cold_boot)
 		if (rc)
 			return rc;
 	}
+
 
 	return 0;
 }

--- a/platform/sifive/fu540/platform.c
+++ b/platform/sifive/fu540/platform.c
@@ -18,6 +18,7 @@
 #include <sbi_utils/irqchip/plic.h>
 #include <sbi_utils/serial/sifive-uart.h>
 #include <sbi_utils/sys/clint.h>
+#include <sbi_utils/experimental/keystone/sm.h>
 
 /* clang-format off */
 
@@ -81,6 +82,8 @@ static int fu540_final_init(bool cold_boot)
 
 	fdt = sbi_scratch_thishart_arg1_ptr();
 	fu540_modify_dt(fdt);
+
+  sm_init();
 
 	return 0;
 }


### PR DESCRIPTION
- Copy relevant headers to include dir
- Change generic platform to init SM in final_init()
- Add SM key parameters at the end of the firmware memory
- Fix Bug and Add FU540 as a platform
- Change handler function of new OpenSBI handler to include `regs` as a
  parameter